### PR TITLE
Add support for CronJobTimeZone feature  (Kubernetes v1.25+)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: release
 
 APP="castai/hibernate"
 TAG_LATEST=$(APP):latest
-TAG_VERSION=$(APP):v0.4
+TAG_VERSION=$(APP):v0.5
 
 gke:
 	(cd ./hack/gke && terraform init && terraform apply -auto-approve)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ kubectl get secret castai-hibernate -n castai-agent -o json | jq --arg API_KEY "
 
 AKS is set by default, but requires changing in both CronJobs "Cloud" env variable to [EKS|GKE|AKS]
 
+### Set Schedule 
+
+Modify the `.spec.schedule` parameter for the Hibernate-pause and Hibernate-resume cronjobs according to  [this syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax). Beginning with Kubernetes v1.25 and later versions, it is possible to define a time zone for a CronJob by assigning a valid time zone name to `.spec.timeZone`. For instance, by assigning `.spec.timeZone: "Etc/UTC"`, Kubernetes will interpret the schedule with respect to Coordinated Universal Time (UTC). To access a list of acceptable time zone options, please refer to the following link: [List of Valid Time Zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+
 ## How it works
 
 Hibernate-pause Job will 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Override default "PROTECT_EVICTION_DISABLED" and set to "true" to prevent the re
 # Development
 
 Create [aks|eks|gke] K8s cluster 
-- create file hack/aks/local.auto.tfvars from example
+- create file hack/aks/tf.vars from example
 - run "make aks"
-- connect to cluster / switch kubectl context
+- connect to cluster (az/gcloud) / switch kubectl context
 
 Run code locally
 - copy cluster_id from console.cast.ai to .env file (example .env.example)

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -122,6 +122,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 22 * * 1-5"
+  timeZone: Asia/Calcutta
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -168,6 +169,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 7 * * 1-5"
+  timeZone: Asia/Calcutta
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -158,7 +158,7 @@ spec:
                   configMapKeyRef:
                     name: castai-cluster-controller
                     key: CLUSTER_ID
-          restartPolicy: Never
+          restartPolicy: OnFailure
       backoffLimit: 0
 ---
 apiVersion: batch/v1
@@ -195,6 +195,6 @@ spec:
                   configMapKeyRef:
                     name: castai-cluster-controller
                     key: CLUSTER_ID
-          restartPolicy: Never
+          restartPolicy: OnFailure
       backoffLimit: 0
 ---

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -126,6 +126,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            autoscaling.cast.ai/removal-disabled: "true"
         spec:
           tolerations:
           - key: "scheduling.cast.ai/paused-cluster"
@@ -172,6 +175,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            autoscaling.cast.ai/removal-disabled: "true"
         spec:
           priorityClassName: system-cluster-critical
           tolerations:

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -122,7 +122,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 22 * * 1-5"
-  timeZone: Asia/Calcutta
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -172,7 +172,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 7 * * 1-5"
-  timeZone: Asia/Calcutta
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/hack/aks/castai.tf
+++ b/hack/aks/castai.tf
@@ -38,38 +38,8 @@ module "castai-aks-cluster" {
       subnets         = [azurerm_subnet.internal.id]
       tags            = var.tags
     }
-
-    test_node_config = {
-      disk_cpu_ratio  = 25
-      subnets         = [azurerm_subnet.internal.id]
-      tags            = var.tags
-      max_pods_per_node = 40
-    }
   }
 
-  node_templates = {
-    spot_tmpl = {
-      configuration_id = module.castai-aks-cluster.castai_node_configurations["default"]
-      should_taint = true
-      custom_label = {
-        key = "custom-key"
-        value = "label-value"
-      }
-
-      constraints = {
-        fallback_restore_rate_seconds = 1800
-        spot = true
-        use_spot_fallbacks = true
-        min_cpu = 4
-        max_cpu = 100
-        instance_families = {
-          exclude = ["standard_DPLSv5"]
-        }
-        compute_optimized = false
-        storage_optimized = false
-      }
-    }
-  }
 
   // Configure Autoscaler policies as per API specification https://api.cast.ai/v1/spec/#/PoliciesAPI/PoliciesAPIUpsertClusterPolicies.
   // Here:


### PR DESCRIPTION
This pull request adds support for setting the timezone in CronJobs by specifying a valid time zon. You can specify a time zone for a CronJob by setting .spec.timeZone to the name of a valid [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example, setting `.spec.timeZone: "Etc/UTC"` instructs Kubernetes to interpret the schedule relative to Coordinated Universal Time.